### PR TITLE
Bug fix Issue 20: Corrupted remote names when using a French locale o…

### DIFF
--- a/src/components/koRemoteFileInfo.py
+++ b/src/components/koRemoteFileInfo.py
@@ -52,6 +52,8 @@ class koRemoteFileInfo:
     _possible_first_chars_for_unix_listing = ("-", "d", "l", "s", "b", "c")
     _3char_month_names = ["jan","feb","mar","apr","may","jun",
                           "jul","aug","sep","oct","nov","dec"]
+    _french_month_names = ["janv.","fevr.","mars","avril","mai","juin",
+                           "juil.","aout","sept.","oct.","nov.","dec."]
     # Encoding is used when encoding is not UTF8 compatible
     encoding = ''
     link_target = None
@@ -272,7 +274,7 @@ class koRemoteFileInfo:
                 # to see if we have a time, or a year?
                 guessedYear = False
                 if fi[5] and (fi[5][0] not in string_digits or
-                              (len(fi[6]) == 3 and fi[6][0] not in string_digits)):
+                              (len(fi[6]) >= 3 and fi[6][0] not in string_digits)):
                     if " " in fi[7] and fi[7][0] in string_digits:
                         # Requires the filename field to be split up:
                         fi = fi[:1] + fi[2:7] + fi[7].split(None, 1)
@@ -296,6 +298,12 @@ class koRemoteFileInfo:
 
                     if len(day) < 2: day = "0"+day
                     if len(hour) < 5: hour = "0"+hour
+                    # Bug fix Issue 20
+                    if month in self._french_month_names: month = self._3char_month_names[self._french_month_names.index(month)]
+                    # Workaround to deal with french accents
+                    if month[0] == 'a' and month[1] == 'o': month = self._3char_month_names[7]
+                    if month[0] == 'f': month = self._3char_month_names[1]
+                    if month[0] == 'd': month = self._3char_month_names[11]
                     date = "%s %s %s %s" % (month, day, year, hour)
                     try:
                         # Note: This can fail due to locale differences between


### PR DESCRIPTION
see issue #20 for more information.

With this fix Komodo is able to parse remote file info on a remote server using a French locale.
Month name can :
- be more than 3 letters
- finish with a dot when month name is truncated
- have an accent

for example:
drwxr-xr-x 13 www  www     4096  9 avril  2020 wapiVote
drwxr-xr-x 14 www  www     4096 23 nov.  13:02 wapiImmo
drwxr-xr-x 13 www  www     4096 15 févr.  2017 wapiGame